### PR TITLE
Couchdb config validation standardization

### DIFF
--- a/receiver/couchdbreceiver/client.go
+++ b/receiver/couchdbreceiver/client.go
@@ -3,6 +3,7 @@ package couchdbreceiver
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -41,7 +42,8 @@ func basicAuth(username, password string) string {
 }
 
 func (c *couchdbClient) Get() (map[string]interface{}, error) {
-	req, err := http.NewRequest("GET", c.cfg.Endpoint, nil)
+	url := fmt.Sprintf("%s/_node/%s/_stats/couchdb", c.cfg.Endpoint, c.cfg.Nodename)
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/couchdbreceiver/client_test.go
+++ b/receiver/couchdbreceiver/client_test.go
@@ -112,7 +112,8 @@ func TestGet(t *testing.T) {
 	})
 	t.Run("no error", func(t *testing.T) {
 		couchdbClient, err := newCouchDBClient(componenttest.NewNopHost(), &Config{
-			Endpoint: couchdbMock.URL + "/_node/_local/_stats/couchdb",
+			Endpoint: couchdbMock.URL,
+			Nodename: "_local",
 		}, zap.NewNop())
 		require.Nil(t, err)
 		require.NotNil(t, couchdbClient)

--- a/receiver/couchdbreceiver/config_test.go
+++ b/receiver/couchdbreceiver/config_test.go
@@ -2,6 +2,7 @@ package couchdbreceiver
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,36 +10,99 @@ import (
 )
 
 func TestValidate(t *testing.T) {
-	testCases := []struct {
-		desc   string
-		cfg    *Config
-		actual error
-	}{
-		{
-			desc: "missing config fields",
-			cfg:  &Config{},
-			actual: multierr.Combine(
-				errors.New(ErrNoUsername),
-				errors.New(ErrNoPassword),
-				errors.New(ErrNoEndpoint),
-			),
-		},
-		{
-			desc: "no error",
-			cfg: &Config{
-				Username: "otel",
-				Password: "otel",
-				Endpoint: "localhost:1234",
+	t.Run("error path", func(t *testing.T) {
+		cfg := &Config{
+			Username: "otelu",
+			Password: "otelp",
+			Endpoint: "http://endpoint with space",
+		}
+		require.Equal(t, errors.New("invalid endpoint 'http://endpoint with space'"), cfg.Validate())
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		testCases := []struct {
+			desc     string
+			rawUrl   string
+			expected string
+		}{
+			{
+				desc:     "default path",
+				rawUrl:   "",
+				expected: "http://localhost:5984",
 			},
-			actual: nil,
-		},
-	}
-	for _, tC := range testCases {
-		t.Run(tC.desc, func(t *testing.T) {
-			expected := tC.cfg.Validate()
-			require.Equal(t, expected, tC.actual)
-		})
-	}
+			{
+				desc:     "only host(local)",
+				rawUrl:   "localhost",
+				expected: "http://localhost:5984",
+			},
+			{
+				desc:     "only host",
+				rawUrl:   "127.0.0.1",
+				expected: "http://127.0.0.1:5984",
+			},
+			{
+				desc:     "host(local) and port",
+				rawUrl:   "localhost:5984",
+				expected: "http://localhost:5984",
+			},
+			{
+				desc:     "host and port",
+				rawUrl:   "127.0.0.1:5984",
+				expected: "http://127.0.0.1:5984",
+			},
+			{
+				desc:     "full path",
+				rawUrl:   "http://localhost:5984/_node/_local/_stats/couchdb",
+				expected: "http://localhost:5984",
+			},
+			{
+				desc:     "full path",
+				rawUrl:   "http://127.0.0.1:5984/_node/_local/_stats/couchdb",
+				expected: "http://127.0.0.1:5984",
+			},
+			{
+				desc:     "unique host no port",
+				rawUrl:   "myAlias.Site",
+				expected: "http://myAlias.Site:5984",
+			},
+			{
+				desc:     "unique host with port",
+				rawUrl:   "myAlias.Site:1234",
+				expected: "http://myAlias.Site:1234",
+			},
+			{
+				desc:     "unique host with port with path",
+				rawUrl:   "myAlias.Site:1234/_node/_local/_stats/couchdb",
+				expected: "http://myAlias.Site:1234",
+			},
+			{
+				desc:     "only port",
+				rawUrl:   ":5984",
+				expected: "http://localhost:5984",
+			},
+			{
+				desc:     "limitation: double port",
+				rawUrl:   "1234",
+				expected: "http://1234:5984",
+			},
+			{
+				desc:     "limitation: invalid ip",
+				rawUrl:   "500.0.0.0.1.1",
+				expected: "http://500.0.0.0.1.1:5984",
+			},
+		}
+		for _, tC := range testCases {
+			t.Run(tC.desc, func(t *testing.T) {
+				cfg := &Config{
+					Username: "otelu",
+					Password: "otelp",
+					Endpoint: tC.rawUrl,
+				}
+				require.NoError(t, cfg.Validate())
+				require.Equal(t, tC.expected, cfg.Endpoint)
+			})
+		}
+	})
 }
 
 func TestValidateMissingFields(t *testing.T) {
@@ -48,32 +112,20 @@ func TestValidateMissingFields(t *testing.T) {
 		actual error
 	}{
 		{
-			desc: "missing username, password, endpoint",
+			desc: "missing username and password",
 			cfg:  &Config{},
 			actual: multierr.Combine(
 				errors.New(ErrNoUsername),
 				errors.New(ErrNoPassword),
-				errors.New(ErrNoEndpoint),
 			),
 		},
 		{
-			desc: "missing password, endpoint",
+			desc: "missing password",
 			cfg: &Config{
 				Username: "otel",
 			},
 			actual: multierr.Combine(
 				errors.New(ErrNoPassword),
-				errors.New(ErrNoEndpoint),
-			),
-		},
-		{
-			desc: "missing endpoint",
-			cfg: &Config{
-				Username: "otel",
-				Password: "otel",
-			},
-			actual: multierr.Combine(
-				errors.New(ErrNoEndpoint),
 			),
 		},
 		{
@@ -81,7 +133,6 @@ func TestValidateMissingFields(t *testing.T) {
 			cfg: &Config{
 				Username: "otel",
 				Password: "otel",
-				Endpoint: "localhost:1234",
 			},
 			actual: nil,
 		},
@@ -94,54 +145,92 @@ func TestValidateMissingFields(t *testing.T) {
 	}
 }
 
-func TestCheckInvalidFields(t *testing.T) {
+func TestMissingProtocol(t *testing.T) {
 	testCases := []struct {
 		desc     string
-		endpoint string
-		actual   error
+		proto    string
+		expected bool
 	}{
 		{
-			desc:     "multiple colons",
-			endpoint: "localhost:1234:1234",
-			actual:   errors.New(ErrInvalidEndpoint),
+			desc:     "http proto",
+			proto:    "http://localhost",
+			expected: false,
 		},
 		{
-			desc:     "no host",
-			endpoint: ":1234",
-			actual:   errors.New(ErrNoHost),
+			desc:     "https proto",
+			proto:    "https://localhost",
+			expected: false,
 		},
 		{
-			desc:     "no port",
-			endpoint: "localhost:",
-			actual:   errors.New(ErrNoPort),
+			desc:     "HTTP caps",
+			proto:    "HTTP://localhost",
+			expected: false,
 		},
 		{
-			desc:     "invalid port",
-			endpoint: "localhost:acbd",
-			actual:   errors.New(ErrInvalidPort),
+			desc:     "everything else",
+			proto:    "ht",
+			expected: true,
 		},
 		{
-			desc:     "no error",
-			endpoint: "localhost:1234",
-			actual:   nil,
+			desc:     "everything else",
+			proto:    "localhost",
+			expected: true,
 		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			expected := ValidateEndpoint(tC.endpoint)
-			require.Equal(t, expected, tC.actual)
+			require.Equal(t, tC.expected, missingProtocol(tC.proto))
 		})
 	}
 }
 
-func TestMakeClientEndpoint(t *testing.T) {
-	cfg := Config{
-		Username: "otelu",
-		Password: "otelp",
-		Endpoint: "localhost:5984",
-		Nodename: "_local",
+func TestValidateEndpointFormat(t *testing.T) {
+	protocols := []string{"", "http://", "https://"}
+	hosts := []string{"", "127.0.0.1", "localhost", "customhost.com"}
+	ports := []string{"", ":5984", ":1234"}
+	paths := []string{"", "/server-status", "/nonsense"}
+	queries := []string{"", "/?auto", "/?nonsense"}
+	endpoints := []string{}
+	validEndpoints := map[string]bool{
+		"http://127.0.0.1:5984":      true,
+		"http://127.0.0.1:1234":      true,
+		"http://localhost:5984":      true,
+		"http://localhost:1234":      true,
+		"http://customhost.com:5984": true,
+		"http://customhost.com:1234": true,
+		// https
+		"https://127.0.0.1:5984":      true,
+		"https://127.0.0.1:1234":      true,
+		"https://localhost:5984":      true,
+		"https://localhost:1234":      true,
+		"https://customhost.com:5984": true,
+		"https://customhost.com:1234": true,
 	}
-	expected := cfg.MakeClientEndpoint()
-	actual := "http://localhost:5984/_node/_local/_stats/couchdb"
-	require.Equal(t, expected, actual)
+
+	for _, protocol := range protocols {
+		for _, host := range hosts {
+			for _, port := range ports {
+				for _, path := range paths {
+					for _, query := range queries {
+						endpoint := fmt.Sprintf("%s%s%s%s%s", protocol, host, port, path, query)
+						endpoints = append(endpoints, endpoint)
+					}
+				}
+			}
+		}
+	}
+
+	for _, endpoint := range endpoints {
+		t.Run(endpoint, func(t *testing.T) {
+			cfg := &Config{
+				Username: "otelu",
+				Password: "otelp",
+				Endpoint: endpoint,
+			}
+			err := cfg.Validate()
+			require.NoError(t, err)
+			_, ok := validEndpoints[cfg.Endpoint]
+			require.True(t, ok)
+		})
+	}
 }

--- a/receiver/couchdbreceiver/factory.go
+++ b/receiver/couchdbreceiver/factory.go
@@ -35,6 +35,7 @@ func createDefaultConfig() config.Receiver {
 			Timeout: 10 * time.Second,
 		},
 		Nodename: "_local",
+		Endpoint: "http://localhost:5984",
 	}
 }
 

--- a/receiver/couchdbreceiver/factory.go
+++ b/receiver/couchdbreceiver/factory.go
@@ -45,11 +45,6 @@ func createMetricsReceiver(
 	consumer consumer.Metrics,
 ) (component.MetricsReceiver, error) {
 	cfg := rConf.(*Config)
-	err := cfg.Validate()
-	if err != nil {
-		return nil, err
-	}
-	cfg.Endpoint = cfg.MakeClientEndpoint()
 
 	ns := newCouchdbScraper(params.Logger, cfg)
 	scraper := scraperhelper.NewResourceMetricsScraper(cfg.ID(), ns.scrape, scraperhelper.WithStart(ns.start))

--- a/receiver/couchdbreceiver/factory_test.go
+++ b/receiver/couchdbreceiver/factory_test.go
@@ -2,7 +2,6 @@ package couchdbreceiver
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -12,7 +11,6 @@ import (
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.opentelemetry.io/collector/testbed/testbed"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
 
@@ -29,46 +27,21 @@ func TestValidConfig(t *testing.T) {
 }
 
 func TestCreateMetricsReceiver(t *testing.T) {
-	t.Run("validation error, missing config fields", func(t *testing.T) {
-		factory := NewFactory()
-		metricsReceiver, err := factory.CreateMetricsReceiver(
-			context.Background(),
-			component.ReceiverCreateSettings{Logger: zap.NewNop()},
-			&Config{
-				ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
-					ReceiverSettings:   config.NewReceiverSettings(config.NewID("couchdb")),
-					CollectionInterval: 10 * time.Second,
-				},
+	factory := NewFactory()
+	metricsReceiver, err := factory.CreateMetricsReceiver(
+		context.Background(),
+		component.ReceiverCreateSettings{Logger: zap.NewNop()},
+		&Config{
+			ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
+				ReceiverSettings:   config.NewReceiverSettings(config.NewID("couchdb")),
+				CollectionInterval: 10 * time.Second,
 			},
-			&testbed.MockMetricConsumer{},
-		)
-		require.Error(t, err)
-		expectedErr := multierr.Combine(
-			errors.New(ErrNoUsername),
-			errors.New(ErrNoPassword),
-			errors.New(ErrNoEndpoint),
-		)
-		require.Equal(t, expectedErr, err)
-		require.Nil(t, metricsReceiver)
-	})
-
-	t.Run("no error", func(t *testing.T) {
-		factory := NewFactory()
-		metricsReceiver, err := factory.CreateMetricsReceiver(
-			context.Background(),
-			component.ReceiverCreateSettings{Logger: zap.NewNop()},
-			&Config{
-				ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
-					ReceiverSettings:   config.NewReceiverSettings(config.NewID("couchdb")),
-					CollectionInterval: 10 * time.Second,
-				},
-				Username: "otelu",
-				Password: "otelp",
-				Endpoint: "localhost:5984",
-			},
-			&testbed.MockMetricConsumer{},
-		)
-		require.NoError(t, err)
-		require.NotNil(t, metricsReceiver)
-	})
+			Username: "otelu",
+			Password: "otelp",
+			Endpoint: "localhost:5984",
+		},
+		&testbed.MockMetricConsumer{},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, metricsReceiver)
 }


### PR DESCRIPTION
- removed duplicated config validation call in factory
- moved the metric path endpoint to be called in the client
- added sensible default parameters for the endpoint