### PR TITLE
refactored metrics to directly be stored in ResourceMetricsSlice

### DIFF
--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -100,8 +100,8 @@ func (r *elasticsearchScraper) scrape(context.Context) (pdata.ResourceMetricsSli
 	}
 
 	r.now = pdata.TimestampFromTime(time.Now())
-	metrics := pdata.NewMetrics()
-	ilm := metrics.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
+	rms := pdata.NewResourceMetricsSlice()
+	ilm := rms.AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
 	ilm.InstrumentationLibrary().SetName("otel/elasticsearch")
 	nodesInter := nodeStats["nodes"]
 	nodes, ok := nodesInter.(map[string]interface{})
@@ -235,7 +235,7 @@ func (r *elasticsearchScraper) scrape(context.Context) (pdata.ResourceMetricsSli
 	r.processFloatMetric([]string{"unassigned_shards"}, clusterHealth, ShardsMetric, labels)
 	labels.Delete(metadata.L.ShardType)
 
-	return metrics.ResourceMetrics(), nil
+	return rms, nil
 }
 
 func getFloatFromBody(keys []string, body map[string]interface{}) (float64, error) {

--- a/receiver/httpdreceiver/scraper.go
+++ b/receiver/httpdreceiver/scraper.go
@@ -77,8 +77,8 @@ func (r *httpdScraper) scrape(context.Context) (pdata.ResourceMetricsSlice, erro
 		return pdata.ResourceMetricsSlice{}, err
 	}
 
-	metrics := pdata.NewMetrics()
-	ilm := metrics.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
+	rms := pdata.NewResourceMetricsSlice()
+	ilm := rms.AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
 	ilm.InstrumentationLibrary().SetName("otel/httpd")
 	now := pdata.TimestampFromTime(time.Now())
 
@@ -133,7 +133,7 @@ func (r *httpdScraper) scrape(context.Context) (pdata.ResourceMetricsSlice, erro
 		}
 	}
 
-	return metrics.ResourceMetrics(), nil
+	return rms, nil
 }
 
 // GetStats collects metric stats by making a get request at an endpoint.

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -143,8 +143,8 @@ func (r *mongodbScraper) scrape(ctx context.Context) (pdata.ResourceMetricsSlice
 		}
 	}()
 
-	metrics := pdata.NewMetrics()
-	ilm := metrics.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
+	rms := pdata.NewResourceMetricsSlice()
+	ilm := rms.AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
 	ilm.InstrumentationLibrary().SetName("otelcol/mongodb")
 	mm := newMetricManager(r.logger, ilm)
 
@@ -179,7 +179,7 @@ func (r *mongodbScraper) scrape(ctx context.Context) (pdata.ResourceMetricsSlice
 		}
 	}
 
-	return metrics.ResourceMetrics(), nil
+	return rms, nil
 }
 
 func (r *mongodbScraper) parseSpecialMetrics(ctx context.Context, mm *metricManager, document bson.M) {

--- a/receiver/rabbitmqreceiver/scraper.go
+++ b/receiver/rabbitmqreceiver/scraper.go
@@ -70,8 +70,8 @@ func (r *rabbitmqScraper) scrape(context.Context) (pdata.ResourceMetricsSlice, e
 	if err != nil {
 		return pdata.ResourceMetricsSlice{}, err
 	}
-	metrics := pdata.NewMetrics()
-	ilm := metrics.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
+	rms := pdata.NewResourceMetricsSlice()
+	ilm := rms.AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
 	ilm.InstrumentationLibrary().SetName("otel/rabbitmq")
 	now := pdata.TimestampFromTime(time.Now())
 
@@ -159,7 +159,7 @@ func (r *rabbitmqScraper) scrape(context.Context) (pdata.ResourceMetricsSlice, e
 		}
 	}
 
-	return metrics.ResourceMetrics(), nil
+	return rms, nil
 }
 
 func getValFromBody(keys []string, body map[string]interface{}) (float64, error) {


### PR DESCRIPTION
Updated metrics that add a new resource metrics, to instead just initialize new resource metric.

git suggestion [bogdandrutu  nit](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5141/files) 